### PR TITLE
Remove unneccesarily specific postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   },
   "scripts": {
     "start": "node server.js",
-    "postinstall": "node_modules/.bin/bower install"
+    "postinstall": "bower install"
   }
 }


### PR DESCRIPTION
When npm runs a script, it does it with a $PATH that includes the local `node_modues/.bin` or whatever other path it has used to install the binaries. There is no need to specify it.
